### PR TITLE
use os.makedirs()

### DIFF
--- a/pelican_dynamic.py
+++ b/pelican_dynamic.py
@@ -50,7 +50,7 @@ def copy_resources(src, dest, file_list):
     Copies files from content to output
     """
     if not os.path.exists(dest):
-        os.mkdir(dest)
+        os.makedirs(dest)
     for file_ in file_list:
         file_src = os.path.join(src, file_)
         shutil.copy2(file_src, dest)


### PR DESCRIPTION
Fixes issue of missing intermediary dirs.